### PR TITLE
chore(composer): Update dotCMS PHP SDK version in examples

### DIFF
--- a/examples/dotcms-laravel/composer.json
+++ b/examples/dotcms-laravel/composer.json
@@ -8,12 +8,6 @@
         "framework"
     ],
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../../"
-        }
-    ],
     "require": {
         "php": "^8.2",
         "dotcms/php-sdk": "^1.0.0",

--- a/examples/dotcms-php/composer.json
+++ b/examples/dotcms-php/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "dotcms/php-sdk": "dev-main"
+        "dotcms/php-sdk": "^1.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/examples/dotcms-symfony/composer.json
+++ b/examples/dotcms-symfony/composer.json
@@ -3,14 +3,8 @@
     "license": "proprietary",
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../../"
-        }
-    ],
     "require": {
-        "dotcms/php-sdk": "^1.0",
+        "dotcms/php-sdk": "^1.0.0",
         "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",


### PR DESCRIPTION
- Changed SDK version from "dev-main" to "^1.0.0" in dotcms-php and dotcms-symfony examples.
- Removed unnecessary repositories section in dotcms-laravel example.