### PR TITLE
adds home link to simfony header for parity w/laravel

### DIFF
--- a/examples/dotcms-symfony/templates/dotcms/header.twig
+++ b/examples/dotcms-symfony/templates/dotcms/header.twig
@@ -1,7 +1,8 @@
 <header class="container">
     <div class="grid">
         <div>
-            <h1>{{ pageAsset.page.title }}</h1>
+            <h1><a href="/" style="text-decoration:none; color:inherit;">TravelLux in Symfony</a></h1>
+            {# or page title via {{ pageAsset.page.title }} #}
         </div>
         <div>
             {% include 'dotcms/components/navigation.twig' with { 'navigation': navigation } %}


### PR DESCRIPTION
This is a little nothing edit, just turns the H1 into a home link in the symfony example to match the Laravel one. (It was bugging me that I could navigate from, but not back to, Home.)

Ditches the page title for the site title, though I left the page title variable as a comment.